### PR TITLE
Added nimja remove nimWebTemplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ plugins for prologue
 
 * [nim-templates](https://github.com/onionhammer/nim-templates) A simple string templating library for Nim.
 
-* [nimWebTemplates](https://github.com/enthus1ast/nimWebTemplates) Experiment to build a jinja like template parser.
+* [nimja](https://github.com/enthus1ast/nimja) Typed and compiled template engine inspired by jinja2, twig and onionhammer/nim-templates for Nim. 
 
 * [nim-html-dsl](https://github.com/juancarlospaco/nim-html-dsl) Nim HTML DSL.
 


### PR DESCRIPTION
nimWebTemplates are unmaintained the only advantage over nimja is that they work on runtime.
But i plan to also lift this restriction with dynamic compilation for nimja, in all other aspects nimja is superior.